### PR TITLE
fix: decouple monitorNewItems from addOptions.monitor

### DIFF
--- a/src/services/lidarr.js
+++ b/src/services/lidarr.js
@@ -2420,7 +2420,7 @@ export function createLidarrService(ctx) {
         rootFolderPath: String(rootFolder.path || ''),
         path: buildArtistPath(rootFolder.path, match),
         monitored: true,
-        monitorNewItems: newArtistMonitoringMode,
+        monitorNewItems: 'none',
         addOptions: {
           monitor: newArtistMonitoringMode,
           searchForMissingAlbums: Boolean(options.searchForMissingAlbums),


### PR DESCRIPTION
monitorNewItems only accepts 'all' or 'none'; setting it to anything else (eg 'latest', 'first', which are valid for addOptions.monitor but not this field) causes Lidarr to return a validation error for any non-'none' monitoring mode. Opt to hardcode 'none' since Curatorr manages catalog expansion itself.