### PR TITLE
Add live search to the include/exclude folder selectors (#144)

### DIFF
--- a/public/styles-curatorr.css
+++ b/public/styles-curatorr.css
@@ -9037,6 +9037,29 @@ html[data-square-corners="1"] .blend-compat-score-wrap {
   color: var(--muted, #888);
   font-size: 12px;
 }
+.spm-wizard-folder-search {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 8px;
+  min-height: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--border, rgba(255,255,255,0.12));
+  background: var(--surface-1, #1a1a1a);
+  color: var(--text, #e0e0e0);
+  padding: 8px 12px;
+  font-size: 13px;
+}
+.spm-wizard-folder-search::placeholder {
+  color: var(--muted, rgba(255,255,255,0.55));
+}
+.spm-wizard-folder-search:focus {
+  outline: none;
+  border-color: rgba(var(--brand-rgb), 0.55);
+}
+.spm-wizard-folder-open[disabled] {
+  cursor: default;
+  opacity: 0.85;
+}
 .spm-wizard-folder-list {
   display: flex;
   flex-direction: column;

--- a/public/styles-settings.css
+++ b/public/styles-settings.css
@@ -6514,9 +6514,41 @@ html[data-square-corners="1"] .widget-card-customize-panel {
   font-size: 11px;
 }
 
+.gp-browser-search {
+  width: 100%;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  border: none;
+  border-bottom: 1px solid var(--border, #333);
+  background: var(--bg-subtle, rgba(255,255,255,0.04));
+  color: var(--text, #e6edf7);
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.gp-browser-search::placeholder {
+  color: var(--text-muted, #999);
+  opacity: 0.72;
+}
+
+.gp-browser-search:focus {
+  outline: none;
+  border-bottom-color: rgba(var(--brand-rgb), 0.55);
+}
+
 .gp-browser-list {
   overflow-y: auto;
   flex: 1;
+}
+
+.gp-browser-row-path {
+  font-size: 10px;
+  font-family: monospace;
+  color: var(--text-muted, #999);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 50%;
 }
 
 .gp-browser-row {

--- a/src/views/playlists.ejs
+++ b/src/views/playlists.ejs
@@ -4532,6 +4532,7 @@
     var _wizardEditKind = null;
     var _wizardEditId = '';
     var _wizardFolderBrowse = { include: '', exclude: '' };
+    var _wizardFolderSearch = { include: '', exclude: '' };
 
     var WIZARD_BUILTIN_TEMPLATES = [
       { id: 'blank',            icon: '✦', name: 'Custom',      description: 'Start clean and shape it yourself.', rules: {}, trackFilters: null },
@@ -5305,6 +5306,32 @@
       }, []).sort(function(a, b) { return a.name.localeCompare(b.name); });
     }
 
+    // Flat search across every folder in the library so users with thousands of
+    // artists can jump straight to one instead of drilling the tree by hand.
+    function wizardFolderSearchResults(query) {
+      var q = String(query || '').trim().toLowerCase();
+      if (!q) return [];
+      var seen = new Set();
+      var out = [];
+      ALL_PATH_SEGMENTS.forEach(function(path) {
+        var parts = path.split('/');
+        for (var i = 0; i < parts.length; i++) {
+          var name = parts[i];
+          if (!name || name.toLowerCase().indexOf(q) === -1) continue;
+          var fullPath = parts.slice(0, i + 1).join('/');
+          if (seen.has(fullPath)) continue;
+          seen.add(fullPath);
+          out.push({ name: name, path: fullPath });
+        }
+      });
+      out.sort(function(a, b) {
+        var ap = a.name.toLowerCase().indexOf(q) === 0, bp = b.name.toLowerCase().indexOf(q) === 0;
+        if (ap !== bp) return ap ? -1 : 1;
+        return a.path.localeCompare(b.path);
+      });
+      return out;
+    }
+
     function wizardApplyTemplate(templateId) {
       var currentName = _wizardState.name || '';
       var currentTarget = _wizardState.playlistTarget || 'personal';
@@ -5369,6 +5396,7 @@
       _wizardState = wizardDefaultState();
       wizardSyncSuggestedName(_wizardState, true);
       _wizardFolderBrowse = { include: '', exclude: '' };
+      _wizardFolderSearch = { include: '', exclude: '' };
       if (_wizardPendingPrefill) {
         Object.assign(_wizardState, _wizardPendingPrefill);
         wizardSyncSuggestedName(_wizardState, false);
@@ -6041,6 +6069,38 @@
         var chips = (selected || []).map(function(folder) {
           return '<span class="spm-folder-chip" data-folder="' + escH(folder) + '">' + escH(folder) + '<button type="button" class="spm-folder-chip-remove" aria-label="Remove">×</button></span>';
         }).join('');
+        var searchVal = _wizardFolderSearch[kind] || '';
+        var searching = searchVal.trim().length > 0;
+        var searchInput = '<input type="text" class="spm-wizard-folder-search" data-folder-search="' + kind + '" value="' + escH(searchVal) + '" placeholder="Search artists / folders… e.g. stef" autocomplete="off" />';
+        var FOLDER_SEARCH_LIMIT = 200;
+        var listInner;
+        if (searching) {
+          var results = wizardFolderSearchResults(searchVal);
+          if (!results.length) {
+            listInner = '<div class="spm-wizard-folder-empty">No folders match "' + escH(searchVal.trim()) + '".</div>';
+          } else {
+            listInner = results.slice(0, FOLDER_SEARCH_LIMIT).map(function(r) {
+              return '<div class="spm-wizard-folder-item">' +
+                '<button type="button" class="spm-wizard-folder-open" disabled>' +
+                  '<span>' + escH(r.name) + '</span>' +
+                  (r.path !== r.name ? '<span class="spm-wizard-folder-open-meta">' + escH(r.path) + '</span>' : '') +
+                '</button>' +
+                '<button type="button" class="btn btn-ghost spm-wizard-folder-add" data-folder-add="' + kind + '" data-folder-path="' + escH(r.path) + '">Add</button>' +
+              '</div>';
+            }).join('') +
+            (results.length > FOLDER_SEARCH_LIMIT ? '<div class="spm-wizard-folder-empty">Showing first ' + FOLDER_SEARCH_LIMIT + ' of ' + results.length + ' matches — keep typing to narrow it down.</div>' : '');
+          }
+        } else {
+          listInner = children.length ? children.map(function(child) {
+            return '<div class="spm-wizard-folder-item">' +
+              '<button type="button" class="spm-wizard-folder-open" data-folder-open="' + kind + '" data-folder-path="' + escH(child.path) + '">' +
+                '<span>' + escH(child.name) + '</span>' +
+                '<span class="spm-wizard-folder-open-meta">' + (child.hasChildren ? 'Open' : 'Leaf') + '</span>' +
+              '</button>' +
+              '<button type="button" class="btn btn-ghost spm-wizard-folder-add" data-folder-add="' + kind + '" data-folder-path="' + escH(child.path) + '">Add</button>' +
+            '</div>';
+          }).join('') : '<div class="spm-wizard-folder-empty">No deeper folders here.</div>';
+        }
         return '<div class="spm-filter-section spm-wizard-accordion' + (sectionOpen ? ' is-open' : '') + '" data-advanced-kind="' + kind + '">' +
           '<button type="button" class="spm-wizard-accordion-toggle" data-advanced-toggle="' + kind + '">' +
             '<span class="spm-filter-label">' + label + '</span>' +
@@ -6048,6 +6108,8 @@
           '</button>' +
           '<div class="spm-wizard-accordion-panel"' + (sectionOpen ? '' : ' hidden') + ' data-advanced-panel="' + kind + '">' +
           '<div class="spm-wizard-folder-browser">' +
+            searchInput +
+            (searching ? '' :
             '<div class="spm-wizard-folder-row">' +
               '<button type="button" class="btn btn-ghost spm-folder-nav-btn" data-folder-root="' + kind + '"' + (currentPath ? '' : ' disabled') + '>Top level</button>' +
               '<button type="button" class="btn btn-ghost spm-folder-nav-btn" data-folder-up="' + kind + '"' + (currentPath ? '' : ' disabled') + '>Up</button>' +
@@ -6058,18 +6120,8 @@
                   return '<span class="spm-wizard-folder-sep">/</span><button type="button" class="spm-wizard-folder-crumb' + (crumbPath === currentPath ? ' is-current' : '') + '" data-folder-browse="' + kind + '" data-folder-path="' + escH(crumbPath) + '">' + escH(part) + '</button>';
                 }).join('') +
               '</div>' +
-            '</div>' +
-            '<div class="spm-wizard-folder-list">' +
-              (children.length ? children.map(function(child) {
-                return '<div class="spm-wizard-folder-item">' +
-                  '<button type="button" class="spm-wizard-folder-open" data-folder-open="' + kind + '" data-folder-path="' + escH(child.path) + '">' +
-                    '<span>' + escH(child.name) + '</span>' +
-                    '<span class="spm-wizard-folder-open-meta">' + (child.hasChildren ? 'Open' : 'Leaf') + '</span>' +
-                  '</button>' +
-                  '<button type="button" class="btn btn-ghost spm-wizard-folder-add" data-folder-add="' + kind + '" data-folder-path="' + escH(child.path) + '">Add</button>' +
-                '</div>';
-              }).join('') : '<div class="spm-wizard-folder-empty">No deeper folders here.</div>') +
-            '</div>' +
+            '</div>') +
+            '<div class="spm-wizard-folder-list">' + listInner + '</div>' +
           '</div>' +
           '<div class="spm-wizard-field-hint">' + (kind === 'include' ? 'If any folders are included, only tracks from those folders are eligible.' : 'Excluded folders are removed before rules are evaluated.') + '</div>' +
           '<div class="spm-folder-chip-row" id="wiz-folder-' + kind + '-chips">' + chips + '</div>' +
@@ -7050,6 +7102,21 @@
           btn.addEventListener('click', function() {
             _wizardState.activeAdvancedSection = btn.dataset.advancedToggle || 'include';
             wizardRenderStep(4);
+          });
+        });
+        document.querySelectorAll('#spm-wizard-body [data-folder-search]').forEach(function(input) {
+          input.addEventListener('input', function() {
+            var kind = input.dataset.folderSearch;
+            var caret = input.selectionStart;
+            _wizardFolderSearch[kind] = input.value;
+            wizardSaveStateFromStep(4);
+            wizardRenderStep(4);
+            // Re-render replaces the input, so restore focus and caret to keep typing.
+            var next = document.querySelector('#spm-wizard-body [data-folder-search="' + kind + '"]');
+            if (next) {
+              next.focus();
+              try { next.setSelectionRange(caret, caret); } catch (e) {}
+            }
           });
         });
         ['include', 'exclude'].forEach(function(kind) {

--- a/src/views/settings.ejs
+++ b/src/views/settings.ejs
@@ -1689,6 +1689,7 @@
                       <span class="gp-browser-path" id="gp-include-path">/</span>
                       <button type="button" class="btn btn-sm btn-ghost gp-browser-add-current" id="gp-include-add-current" style="display:none">+ Add this folder</button>
                     </div>
+                    <input type="text" class="gp-browser-search" id="gp-include-search" placeholder="Search artists / folders… e.g. stef" autocomplete="off" />
                     <div class="gp-browser-list" id="gp-include-list"></div>
                   </div>
                   <div class="gp-folder-chips" id="gp-include-chips"></div>
@@ -1700,6 +1701,7 @@
                       <span class="gp-browser-path" id="gp-exclude-path">/</span>
                       <button type="button" class="btn btn-sm btn-ghost gp-browser-add-current" id="gp-exclude-add-current" style="display:none">+ Add this folder</button>
                     </div>
+                    <input type="text" class="gp-browser-search" id="gp-exclude-search" placeholder="Search artists / folders… e.g. stef" autocomplete="off" />
                     <div class="gp-browser-list" id="gp-exclude-list"></div>
                   </div>
                   <div class="gp-folder-chips" id="gp-exclude-chips"></div>
@@ -1980,6 +1982,9 @@
                 var _ic = document.getElementById('gp-include-chips'); if (_ic) _ic.innerHTML = '';
                 var _ec = document.getElementById('gp-exclude-chips'); if (_ec) _ec.innerHTML = '';
                 _gpFolderNav = { include: [], exclude: [] };
+                _gpFolderSearch = { include: '', exclude: '' };
+                var _is = document.getElementById('gp-include-search'); if (_is) _is.value = '';
+                var _es = document.getElementById('gp-exclude-search'); if (_es) _es.value = '';
                 gpRenderFolderBrowser('include');
                 gpRenderFolderBrowser('exclude');
                 document.getElementById('gp-dedup-mbid').checked = false;
@@ -2084,8 +2089,88 @@
               })();
 
               var _gpFolderNav = { include: [], exclude: [] };
+              var _gpFolderSearch = { include: '', exclude: '' };
+
+              // Flattened list of every distinct folder in the tree, used by the
+              // search box so users can jump straight to an artist without drilling.
+              var _GP_ALL_FOLDERS = (function() {
+                var out = [];
+                (function walk(node, prefix) {
+                  Object.keys(node).forEach(function(name) {
+                    var path = prefix ? prefix + '/' + name : name;
+                    out.push({ name: name, path: path, lower: name.toLowerCase() });
+                    walk(node[name], path);
+                  });
+                })(_GP_FOLDER_TREE, '');
+                return out;
+              })();
+
+              function gpRenderFolderSearchResults(type, query) {
+                var listEl = document.getElementById('gp-' + type + '-list');
+                if (!listEl) return;
+                var pathEl = document.getElementById('gp-' + type + '-path');
+                if (pathEl) pathEl.textContent = 'Search: ' + query;
+                var addCurBtn = document.getElementById('gp-' + type + '-add-current');
+                if (addCurBtn) addCurBtn.style.display = 'none';
+                listEl.innerHTML = '';
+
+                var matches = _GP_ALL_FOLDERS.filter(function(f) { return f.lower.indexOf(query) !== -1; });
+                // Prefix matches first (typing "stef" surfaces "Stef Bos" before "..."), then A→Z.
+                matches.sort(function(a, b) {
+                  var ap = a.lower.indexOf(query) === 0, bp = b.lower.indexOf(query) === 0;
+                  if (ap !== bp) return ap ? -1 : 1;
+                  return a.path.localeCompare(b.path);
+                });
+
+                if (!matches.length) {
+                  var none = document.createElement('div');
+                  none.className = 'tf-empty-hint'; none.style.padding = '6px 10px';
+                  none.textContent = 'No folders match "' + query + '".';
+                  listEl.appendChild(none);
+                  return;
+                }
+
+                var LIMIT = 200;
+                matches.slice(0, LIMIT).forEach(function(f) {
+                  var row = document.createElement('div');
+                  row.className = 'gp-browser-row';
+
+                  var nameSpan = document.createElement('span');
+                  nameSpan.className = 'gp-browser-row-name';
+                  nameSpan.textContent = f.name;
+                  row.appendChild(nameSpan);
+
+                  // Show the parent path so same-named folders can be told apart.
+                  if (f.path !== f.name) {
+                    var pathHint = document.createElement('span');
+                    pathHint.className = 'gp-browser-row-path';
+                    pathHint.textContent = f.path;
+                    row.appendChild(pathHint);
+                  }
+
+                  var addBtn = document.createElement('button');
+                  addBtn.type = 'button';
+                  addBtn.className = 'btn btn-sm btn-ghost gp-browser-add-btn';
+                  addBtn.textContent = '+ Add';
+                  (function(p) {
+                    addBtn.addEventListener('click', function() { gpAddFolderChip(type, p, true); });
+                  })(f.path);
+                  row.appendChild(addBtn);
+
+                  listEl.appendChild(row);
+                });
+
+                if (matches.length > LIMIT) {
+                  var more = document.createElement('div');
+                  more.className = 'tf-empty-hint'; more.style.padding = '6px 10px';
+                  more.textContent = 'Showing first ' + LIMIT + ' of ' + matches.length + ' matches — keep typing to narrow it down.';
+                  listEl.appendChild(more);
+                }
+              }
 
               function gpRenderFolderBrowser(type) {
+                var query = (_gpFolderSearch[type] || '').trim().toLowerCase();
+                if (query) { gpRenderFolderSearchResults(type, query); return; }
                 var path = _gpFolderNav[type];
                 var node = _GP_FOLDER_TREE;
                 for (var i = 0; i < path.length; i++) node = node[path[i]] || {};
@@ -2175,6 +2260,15 @@
               document.getElementById('gp-exclude-add-current').addEventListener('click', function() {
                 var p = _gpFolderNav['exclude'];
                 if (p.length) gpAddFolderChip('exclude', p.join('/'), true);
+              });
+
+              ['include', 'exclude'].forEach(function(type) {
+                var searchEl = document.getElementById('gp-' + type + '-search');
+                if (!searchEl) return;
+                searchEl.addEventListener('input', function() {
+                  _gpFolderSearch[type] = searchEl.value;
+                  gpRenderFolderBrowser(type);
+                });
               });
 
               gpRenderFolderBrowser('include');


### PR DESCRIPTION
## What this does

Adds a live search box to the **Include Folders** and **Exclude Folders** selectors, as requested in #144.

Once a library has a few thousand artists, the current tree browser forces you to scroll (or drill down level by level) to reach a single artist. This adds a search field above the folder list that filters the entire tree in real time and shows matching folders in a flat list with an **Add** button next to each:

- Typing `stef` jumps straight to `Stef Bos`.
- Typing `fr` surfaces `Frank Boeijen`, `Frank Boeijen Groep` and `Frank Sinatra`.
- Prefix matches sort first, then alphabetically; the parent path is shown so folders with the same name can be told apart.
- Clearing the box restores the normal drill-down navigation.
- Results are capped at 200 with a "keep typing to narrow it down" hint so very large libraries don't flood the DOM.

I applied it in both places that expose this browser: the **Global Playlists** config in Settings and **Step 4** of the Smart Playlist wizard. It reuses the same live-filter idea already used for Genres, Moods and Last.fm Tags, so the behaviour should feel consistent. In the wizard the step re-renders on each keystroke (as it already does elsewhere), so I restore focus and caret position afterwards to keep typing smooth.

## Why

Building curated, folder-scoped playlists on a large library is currently slow because there's no way to jump to an artist. This removes the scrolling without changing any of the existing navigation.

## Testing

- Verified the matching logic against the concrete examples from the issue (`fr`, `stef`, nested matches, substring matches, empty result) for both selectors.
- Confirmed both EJS templates still compile.
- `npm test` passes (194/194) — the change is UI-only (views + CSS), no server logic touched.

## Notes

Purely additive and client-side; no changes to the filter payload, storage, or APIs. The folder data already available to each browser (`allPathSegments`) is reused, so there's no extra server work.
