### PR TITLE
fix: decouple monitorNewItems from addOptions.monitor

### DIFF
--- a/src/services/lidarr.js
+++ b/src/services/lidarr.js
@@ -2482,7 +2482,12 @@ export function createLidarrService(ctx) {
         rootFolderPath: String(rootFolder.path || ''),
         path: buildArtistPath(rootFolder.path, match),
         monitored: true,
-        monitorNewItems: newArtistMonitoringMode,
+        // Lidarr types monitorNewItems as NewItemMonitorTypes (all|none), a narrower
+        // enum than the MonitorTypes set addOptions.monitor accepts. Sending any of
+        // new/existing/latest/first here fails deserialization and rejects the whole
+        // request, so only 'all' can carry over; every other mode narrows to 'none'
+        // and drives addOptions.monitor alone.
+        monitorNewItems: newArtistMonitoringMode === 'all' ? 'all' : 'none',
         addOptions: {
           monitor: newArtistMonitoringMode,
           searchForMissingAlbums: Boolean(options.searchForMissingAlbums),

--- a/src/test/auth.test.js
+++ b/src/test/auth.test.js
@@ -2687,7 +2687,8 @@ describe('security guards', () => {
     assert.equal(config?.lidarr?.newArtistMonitoringMode, 'latest');
   });
 
-  it('uses the configured new-artist monitoring mode in the Lidarr add payload', async () => {
+  // Builds the POST /artist body Curatorr sends for a given configured monitoring mode.
+  async function captureLidarrAddPayload(newArtistMonitoringMode) {
     const lidarrService = createLidarrService({
       db: null,
       loadConfig: () => ({
@@ -2696,7 +2697,7 @@ describe('security guards', () => {
           apiKey: 'lidarr-api-key',
           defaultMetadataProfileId: 4,
           defaultQualityProfileId: 7,
-          newArtistMonitoringMode: 'latest',
+          newArtistMonitoringMode,
         },
       }),
       safeMessage: (err) => String(err?.message || err || ''),
@@ -2749,7 +2750,7 @@ describe('security guards', () => {
           id: 42,
           artistName: 'The National',
           monitored: true,
-          monitorNewItems: 'latest',
+          monitorNewItems: createdArtistPayload?.monitorNewItems || 'none',
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -2766,15 +2767,28 @@ describe('security guards', () => {
           folder: 'the-national',
         },
       });
-      assert.equal(result.created, true);
-      assert.equal(createdArtistPayload?.metadataProfileId, 4);
-      assert.equal(createdArtistPayload?.qualityProfileId, 7);
-      assert.equal(createdArtistPayload?.monitorNewItems, 'latest');
-      assert.equal(createdArtistPayload?.addOptions?.monitor, 'latest');
-      assert.equal(createdArtistPayload?.monitored, true);
+      return { result, payload: createdArtistPayload };
     } finally {
       global.fetch = originalFetch;
     }
+  }
+
+  it('narrows a non-all new-artist monitoring mode to none for monitorNewItems', async () => {
+    const { result, payload } = await captureLidarrAddPayload('latest');
+    assert.equal(result.created, true);
+    assert.equal(payload?.metadataProfileId, 4);
+    assert.equal(payload?.qualityProfileId, 7);
+    assert.equal(payload?.monitored, true);
+    // monitorNewItems is NewItemMonitorTypes (all|none); only addOptions.monitor
+    // accepts the wider set the settings dropdown offers.
+    assert.equal(payload?.monitorNewItems, 'none');
+    assert.equal(payload?.addOptions?.monitor, 'latest');
+  });
+
+  it('passes an all new-artist monitoring mode through to monitorNewItems', async () => {
+    const { payload } = await captureLidarrAddPayload('all');
+    assert.equal(payload?.monitorNewItems, 'all');
+    assert.equal(payload?.addOptions?.monitor, 'all');
   });
 
   it('allows the default weekly Last.fm tag sync interval on the jobs page', async () => {


### PR DESCRIPTION
Lidarr types monitorNewItems as NewItemMonitorTypes, which accepts only 'all' or 'none'. addOptions.monitor is the wider MonitorTypes enum (all/future/missing/existing/latest/first/none). Feeding one configured value into both fields means the settings dropdown's new, existing, latest and first values fail JSON deserialization, and Lidarr rejects the entire POST /artist with "One or more validation errors occurred." Automation then adds no artists at all until the setting is put back to none or all.

Narrow monitorNewItems to the enum it actually takes: pass 'all' through and map every other mode to 'none', while addOptions.monitor keeps the full configured value. Mapping only the illegal values keeps 'all' meaningful for users who do want Lidarr tracking future releases, rather than silently downgrading every mode to 'none'.

This restores #126 (merged as v0.1.85), which was reverted two days later in e66f472 to satisfy a test asserting monitorNewItems === 'latest'. That assertion only passed because the test stubs global.fetch with a mock that returns 200 without validating the enum, so it encoded the bug rather than the contract. The add-payload mock is now shared by two cases asserting the decoupling in both directions: 'latest' yields monitorNewItems 'none' with addOptions.monitor 'latest', and 'all' yields 'all' for both.

--------------------------------------------

I submitted a similar fix in the past, which was merged, but was then reverted because of a failing test, which re-introduced the same problem. This commit includes an updated version of the fix (allowing for either 'all' or 'none') while also updating the relevant tests so that the cycle does not repeat itself.