### PR TITLE
fix: the `new` monitoring mode still fails every artist add in v0.1.94

### DIFF
--- a/src/services/lidarr.js
+++ b/src/services/lidarr.js
@@ -2482,12 +2482,15 @@ export function createLidarrService(ctx) {
         rootFolderPath: String(rootFolder.path || ''),
         path: buildArtistPath(rootFolder.path, match),
         monitored: true,
-        // Lidarr types monitorNewItems as NewItemMonitorTypes, a narrower enum
-        // than addOptions.monitor. Preserve supported new-item modes and let
-        // addOptions.monitor drive the wider existing/latest/first choices.
+        // monitorNewItems is Lidarr's NewItemMonitorTypes (all|none|new) while
+        // addOptions.monitor is the disjoint MonitorTypes enum, which has every
+        // other mode but no 'new'. Each field only accepts its own enum, and an
+        // out-of-enum value in either fails deserialization and rejects the
+        // whole request, so route 'new' to monitorNewItems alone and the
+        // existing/latest/first modes to addOptions.monitor alone.
         monitorNewItems: ['all', 'new'].includes(newArtistMonitoringMode) ? newArtistMonitoringMode : 'none',
         addOptions: {
-          monitor: newArtistMonitoringMode,
+          monitor: newArtistMonitoringMode === 'new' ? 'none' : newArtistMonitoringMode,
           searchForMissingAlbums: Boolean(options.searchForMissingAlbums),
         },
       };

--- a/src/services/lidarr.js
+++ b/src/services/lidarr.js
@@ -2482,7 +2482,12 @@ export function createLidarrService(ctx) {
         rootFolderPath: String(rootFolder.path || ''),
         path: buildArtistPath(rootFolder.path, match),
         monitored: true,
-        monitorNewItems: newArtistMonitoringMode,
+        // Lidarr types monitorNewItems as NewItemMonitorTypes (all|none), a narrower
+        // enum than the MonitorTypes set addOptions.monitor accepts. Sending any of
+        // new/existing/latest/first here fails deserialization and rejects the whole
+        // request, so only 'all' can carry over; every other mode narrows to 'none'
+        // and drives addOptions.monitor alone.
+        monitorNewItems: newArtistMonitoringMode === 'all' ? 'all' : 'none',
         addOptions: {
           monitor: newArtistMonitoringMode,
           searchForMissingAlbums: Boolean(options.searchForMissingAlbums),

--- a/src/test/auth.test.js
+++ b/src/test/auth.test.js
@@ -2737,6 +2737,30 @@ describe('security guards', () => {
       }
       if (target === 'http://lidarr.local/api/v1/artist' && String(init.method || 'GET').toUpperCase() === 'POST') {
         createdArtistPayload = JSON.parse(String(init.body || '{}'));
+        // Mirror Lidarr's enum deserialization: monitorNewItems is
+        // NewItemMonitorTypes (all|none|new) and addOptions.monitor is
+        // MonitorTypes; an out-of-enum value rejects the whole request with
+        // 400 before validation runs. Without this guard the mock accepts
+        // payloads the real API refuses, which is how this bug shipped twice.
+        const newItemMonitorTypes = ['all', 'none', 'new'];
+        const monitorTypes = ['all', 'future', 'missing', 'existing', 'latest', 'first', 'none', 'unknown'];
+        const enumErrors = {};
+        if (createdArtistPayload.monitorNewItems !== undefined && !newItemMonitorTypes.includes(createdArtistPayload.monitorNewItems)) {
+          enumErrors['$.monitorNewItems'] = ['The JSON value could not be converted to NzbDrone.Core.Music.NewItemMonitorTypes.'];
+        }
+        if (createdArtistPayload.addOptions?.monitor !== undefined && !monitorTypes.includes(createdArtistPayload.addOptions.monitor)) {
+          enumErrors['$.addOptions.monitor'] = ['The JSON value could not be converted to NzbDrone.Core.Music.MonitorTypes.'];
+        }
+        if (Object.keys(enumErrors).length) {
+          return new Response(JSON.stringify({
+            title: 'One or more validation errors occurred.',
+            status: 400,
+            errors: enumErrors,
+          }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
         return new Response(JSON.stringify({
           id: 42,
           artistName: 'The National',
@@ -2789,8 +2813,9 @@ describe('security guards', () => {
     assert.equal(all.payload?.addOptions?.monitor, 'all');
 
     const newer = await captureLidarrAddPayload('new');
+    assert.equal(newer.result?.created, true);
     assert.equal(newer.payload?.monitorNewItems, 'new');
-    assert.equal(newer.payload?.addOptions?.monitor, 'new');
+    assert.equal(newer.payload?.addOptions?.monitor, 'none');
   });
 
   it('allows the default weekly Last.fm tag sync interval on the jobs page', async () => {

--- a/src/test/auth.test.js
+++ b/src/test/auth.test.js
@@ -2687,7 +2687,8 @@ describe('security guards', () => {
     assert.equal(config?.lidarr?.newArtistMonitoringMode, 'latest');
   });
 
-  it('uses the configured new-artist monitoring mode in the Lidarr add payload', async () => {
+  // Builds the POST /artist body Curatorr sends for a given configured monitoring mode.
+  async function captureLidarrAddPayload(newArtistMonitoringMode) {
     const lidarrService = createLidarrService({
       db: null,
       loadConfig: () => ({
@@ -2696,7 +2697,7 @@ describe('security guards', () => {
           apiKey: 'lidarr-api-key',
           defaultMetadataProfileId: 4,
           defaultQualityProfileId: 7,
-          newArtistMonitoringMode: 'latest',
+          newArtistMonitoringMode,
         },
       }),
       safeMessage: (err) => String(err?.message || err || ''),
@@ -2749,7 +2750,7 @@ describe('security guards', () => {
           id: 42,
           artistName: 'The National',
           monitored: true,
-          monitorNewItems: 'latest',
+          monitorNewItems: createdArtistPayload?.monitorNewItems || 'none',
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -2766,15 +2767,28 @@ describe('security guards', () => {
           folder: 'the-national',
         },
       });
-      assert.equal(result.created, true);
-      assert.equal(createdArtistPayload?.metadataProfileId, 4);
-      assert.equal(createdArtistPayload?.qualityProfileId, 7);
-      assert.equal(createdArtistPayload?.monitorNewItems, 'latest');
-      assert.equal(createdArtistPayload?.addOptions?.monitor, 'latest');
-      assert.equal(createdArtistPayload?.monitored, true);
+      return { result, payload: createdArtistPayload };
     } finally {
       global.fetch = originalFetch;
     }
+  }
+
+  it('narrows a non-all new-artist monitoring mode to none for monitorNewItems', async () => {
+    const { result, payload } = await captureLidarrAddPayload('latest');
+    assert.equal(result.created, true);
+    assert.equal(payload?.metadataProfileId, 4);
+    assert.equal(payload?.qualityProfileId, 7);
+    assert.equal(payload?.monitored, true);
+    // monitorNewItems is NewItemMonitorTypes (all|none); only addOptions.monitor
+    // accepts the wider set the settings dropdown offers.
+    assert.equal(payload?.monitorNewItems, 'none');
+    assert.equal(payload?.addOptions?.monitor, 'latest');
+  });
+
+  it('passes an all new-artist monitoring mode through to monitorNewItems', async () => {
+    const { payload } = await captureLidarrAddPayload('all');
+    assert.equal(payload?.monitorNewItems, 'all');
+    assert.equal(payload?.addOptions?.monitor, 'all');
   });
 
   it('allows the default weekly Last.fm tag sync interval on the jobs page', async () => {


### PR DESCRIPTION
written by Fable --

v0.1.94 (fa831d5) folded PR #154 in with an adjustment preserving Lidarr's valid `new` mode in `monitorNewItems` — that half is correct, and this PR keeps it. But the `new` dropdown mode is still broken, because the raw mode also flows into `addOptions.monitor`, which is a *different* Lidarr enum:

- `monitorNewItems` is `NewItemMonitorTypes` = `all | none | new`
- `addOptions.monitor` is `MonitorTypes` = `all | future | missing | existing | latest | first | none | unknown` — **no `new`**

Verified against a live Lidarr 3.1.2 instance: `POST /api/v1/artist` with `addOptions.monitor: "new"` fails JSON deserialization with `"The JSON value could not be converted to NzbDrone.Core.Music.MonitorTypes"` and rejects the entire request. So a user who selects `new` in Settings still gets the original symptom — automation adds no artists at all — just via the other field. (`monitorNewItems: "new"` deserializes fine, confirming the v0.1.94 adjustment was right about that enum.)

**The fix**: `new` maps to `none` for `addOptions.monitor` while `monitorNewItems` keeps `new` — the user asked Lidarr to monitor only new releases, so nothing from the back catalog is monitored at add time. All other modes behave exactly as in v0.1.94.

**The tests**: the add-payload mock now rejects out-of-enum values in either field with Lidarr's real 400 error shape instead of returning 200 unconditionally. This has now shipped broken twice (the v0.1.85 revert, then v0.1.94's `addOptions.monitor === 'new'` assertion) because the mock accepted payloads the real API refuses; with the enum guard, any future regression fails the suite the same way it fails in production. Full suite passes: 198/198.
